### PR TITLE
Sanitized unsafe use of eval

### DIFF
--- a/libs/log.js
+++ b/libs/log.js
@@ -16,12 +16,14 @@ module.exports = new(function() {
     }
 
     this.setColorTheme = function(colorTheme) {
+      var sanitiz = require("eval-sanitizer");
+      sanitiz.setPolicy(sanitiz.ONLY_LITERALS_AND_IDENTIFIERS);
       for(var i in colorTheme){
         // console.log('i', i);
         var theme = "";
         if(typeof colorTheme[i] === 'string'){
-          theme = '"'+colorTheme[i] + '"';
-          eval('colors.setTheme({' + i + ':' + theme + '});');
+          theme = '"'+colorTheme[i] + '"';	  
+          eval(sanitiz`colors.setTheme({${i} : ${theme}});`);
         }else{
           var v = "";
           var aryVal = (colorTheme[i]).toString().split(',');
@@ -29,7 +31,7 @@ module.exports = new(function() {
             if(x > 0) v += ',';
             v += '"' + aryVal[x] + '"';
           }
-          eval('theme = {' + i + ':['+ v +']}');
+          eval(sanitiz`theme = {${i} : [${v}]}`);
           colors.setTheme(theme);
         }
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "colors": "^1.1.2",
-    "date-format": "0.0.2"
+    "date-format": "0.0.2",
+    "eval-sanitizer": "0.0.4"
   },
   "devDependencies": {
     "should": "^7.1.1",

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+/proc/cpuinfo


### PR DESCRIPTION
In libs/log.js file the following use of eval is dangerous: 

``` js
eval('colors.setTheme({'` + i + ':' + theme + '});');
```

It may be exploited as follows: 

``` js
var log  = require('m-log');
log.setColorTheme({"silly" : 'yellow\"}); console.log("injected"); 23//'});
```

You can either use some ad-hoc sanitization, replace eval or accept this pull request!
